### PR TITLE
add Rust programs

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+/*/target
+/*/Cargo.lock

--- a/rust/bonus/Cargo.toml
+++ b/rust/bonus/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "simple"
+version = "0.1.0"
+authors = ["Andrew Gallant <jamslam@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "countwords"
+path = "main.rs"
+
+[dependencies]
+anyhow = "1.0.38"
+bstr = "0.2.15"
+fxhash = "0.2.1"
+
+[profile.release]
+debug = true

--- a/rust/bonus/main.rs
+++ b/rust/bonus/main.rs
@@ -1,0 +1,73 @@
+// This is the Rust program I would write if someone asked for a *versatile*
+// program to find the frequency distribution of all the words, regardless of
+// case, in a stream. This handles any file that is at least conventionally
+// UTF-8 (so latin-1 is fine). It also uses the Unicode-aware word segmentation
+// algorithm and Unicode-aware case folding. This is despite NOT using Rust's
+// default Unicode string, since that requires the data to be valid UTF-8.
+//
+// It runs about as fast as the "simple" Rust and Go variants. We do two perf
+// tricks in this program: 1) we use bstr's `to_lowercase_into` to avoid
+// allocating a new string for every word, and 2) we look for an existing word
+// in our hashmap to avoid an allocation via the more idiomatic 'entry' API.
+// (These combined reflects a ~33% improvement in my ad hoc experiments.)
+// According to profiling, a bit over half the runtime is spent in word
+// segmenting. The rest seems somewhat evenly split between the actual
+// lowercasing and hashmap interactions.
+//
+// The gauntlet has been laid down. How hard is to port this program to other
+// languages? And when you do, what does its performance look like?
+
+use std::io::{self, Write};
+
+use bstr::{io::BufReadExt, BStr, BString, ByteSlice};
+use fxhash::{FxHashMap as HashMap};
+
+fn main() {
+    // Rust blocks the broken pipe signal by default, and instead returns it as
+    // an error from `write` if the consumer hangs up. So we look for it here
+    // and exit gracefully, as an end user would expect.
+    if let Err(err) = try_main() {
+        if let Some(ioerr) = err.root_cause().downcast_ref::<io::Error>() {
+            if ioerr.kind() == io::ErrorKind::BrokenPipe {
+                std::process::exit(0);
+            }
+        }
+        eprintln!("{:?}", err);
+    }
+}
+
+fn try_main() -> anyhow::Result<()> {
+    let stdin = io::stdin();
+    let stdin = io::BufReader::new(stdin.lock());
+
+    let mut counts: HashMap<BString, u64> = HashMap::default();
+    let mut buf = BString::from(vec![]);
+    stdin.for_byte_line(|line| {
+        for word in line.words() {
+            // reuse the same buffer for lowercasing---an API not available
+            // in std!---to avoid an alloc for every word.
+            buf.clear();
+            word.as_bytes().to_lowercase_into(&mut buf);
+            increment(&mut counts, buf.as_bstr());
+        }
+        Ok(true)
+    })?;
+
+    let mut ordered: Vec<(BString, u64)> = counts.into_iter().collect();
+    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+    for (word, count) in ordered {
+        writeln!(io::stdout(), "{} {}", word, count)?;
+    }
+    Ok(())
+}
+
+fn increment(counts: &mut HashMap<BString, u64>, word: &BStr) {
+    // While this will do two hash lookups when 'word' is not in the map, it
+    // will only do one lookup and no allocs in the much more common case of
+    // 'word' being in the map.
+    if let Some(count) = counts.get_mut(word) {
+        *count += 1;
+    } else {
+        counts.insert(BString::from(word), 1);
+    }
+}

--- a/rust/optimized-customhashmap/Cargo.toml
+++ b/rust/optimized-customhashmap/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "optimized-customhashmap"
+version = "0.1.0"
+authors = ["Andrew Gallant <jamslam@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "countwords"
+path = "main.rs"
+
+[profile.release]
+debug = true

--- a/rust/optimized-customhashmap/main.rs
+++ b/rust/optimized-customhashmap/main.rs
@@ -1,0 +1,131 @@
+// This version is an approximate port of the optimized C program, which rolls
+// its own custom hash table. The main benefit here, I think, is that the
+// hash can be computed as the bytes are visited in the buffer. When compared
+// to using std's hashmap, this saves a pass over the bytes of each word. It
+// otherwise uses approximately the same buffering technique as the optimized
+// Rust version.
+//
+// On my system, the performance of this program is just about on par with the
+// optimized C variant when the C program is compiled with clang. That same C
+// program compiled with gcc is measurably faster by a bit. I didn't dig into
+// the codegen to figure out why.
+
+use std::{
+    error::Error,
+    io::{self, Read, Write},
+};
+
+fn main() {
+    if let Err(err) = try_main() {
+        eprintln!("{}", err);
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> Result<(), Box<dyn Error>> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    let mut counts = Table::new();
+    let mut buf = vec![0; 64 * (1<<10)];
+    let mut offset = 0;
+    let mut start = None;
+    let mut hash = FNV_OFFSET;
+    loop {
+        let nread = stdin.read(&mut buf[offset..])?;
+        if nread == 0 {
+            if offset > 0 {
+                counts.increment(&buf[..offset+1], hash);
+            }
+            break;
+        }
+        let buf = &mut buf[..offset+nread];
+
+        for i in (0..buf.len()).skip(offset) {
+            let b = buf[i];
+            if b == b' ' || b == b'\n' {
+                if let Some(start) = start.take() {
+                    counts.increment(&buf[start..i], hash);
+                    hash = FNV_OFFSET;
+                }
+            } else {
+                if b'A' <= b && b <= b'Z' {
+                    buf[i] += b'a' - b'A';
+                }
+                if start.is_none() {
+                    start = Some(i);
+                }
+                hash *= FNV_PRIME;
+                hash ^= buf[i] as u64;
+            }
+        }
+        if let Some(ref mut start) = start {
+            offset = buf.len() - *start;
+            buf.copy_within(*start.., 0);
+            *start = 0;
+        } else {
+            offset = 0;
+        }
+    }
+
+    let mut ordered = counts.into_counts();
+    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+
+    for (word, count) in ordered {
+        writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
+    }
+    Ok(())
+}
+
+const HASH_LEN: usize = 64 * (1<<10); // mut be >= number of unique words
+const FNV_OFFSET: u64 = 14695981039346656037;
+const FNV_PRIME: u64 = 1099511628211;
+
+#[derive(Clone, Debug)]
+struct Table {
+    entries: Vec<TableEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct TableEntry {
+    word: Option<Box<[u8]>>,
+    count: u64,
+}
+
+impl Table {
+    fn new() -> Table {
+        Table { entries: vec![TableEntry { word: None, count: 0 }; HASH_LEN] }
+    }
+
+    fn into_counts(self) -> Vec<(Box<[u8]>, u64)> {
+        let mut counts = Vec::with_capacity(self.entries.len());
+        for e in self.entries {
+            let word = match e.word {
+                None => continue,
+                Some(word) => word,
+            };
+            counts.push((word, e.count));
+        }
+        counts
+    }
+
+    fn increment(&mut self, word: &[u8], hash: u64) {
+        let mut index = (hash % (HASH_LEN as u64)) as usize;
+        // if all entries are full, then this loop will never terminate. Alas,
+        // we copy this limitation from the C implementation. Basically,
+        // HASH_LEN must be greater than the total number of unique words.
+        loop {
+            let mut entry = &mut self.entries[index];
+            if let Some(eword) = entry.word.as_deref() {
+                if eword == word {
+                    entry.count += 1;
+                    return;
+                }
+                index = (index + 1) % HASH_LEN;
+            } else {
+                entry.word = Some(word.to_vec().into_boxed_slice());
+                entry.count = 1;
+                return;
+            }
+        }
+    }
+}

--- a/rust/optimized-trie/Cargo.toml
+++ b/rust/optimized-trie/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "optimized-trie"
+version = "0.1.0"
+authors = ["Andrew Gallant <jamslam@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "countwords"
+path = "main.rs"
+
+[profile.release]
+debug = true

--- a/rust/optimized-trie/main.rs
+++ b/rust/optimized-trie/main.rs
@@ -1,0 +1,215 @@
+// This version was an experiment to write a faster version of the word
+// counting program by using a trie. Ultimately, while it's pretty fast, it's
+// not as fast the optimized Go, Rust or C versions using a standard hashmap.
+// My hypothesis was that the trie avoids the need to hash each word, and thus,
+// let's us inspect each byte only once. But this comes at the expense of an
+// additional memory operation for each byte (to traverse the trie). I made
+// that as cheap as I could, but alas, profiling seems to suggest it is still
+// too expensive.
+//
+// Of course, the trie in this program is quite reckless in terms of memory
+// usage. But, it only scales with the number of unique words, and memory usage
+// doesn't appear to be a metric in this particular exercise.
+//
+// Also, since the trie is a finite state machine itself, it somewhat
+// simplifies the buffer handling in the code below. There's no need to keep
+// track of incomplete words/lines. You just advance the state machine. Alas,
+// this doesn't really help with performance, since the tracking is only done
+// once per buffer read.
+
+use std::{
+    error::Error,
+    io::{self, Read, Write},
+};
+
+fn main() {
+    if let Err(err) = try_main() {
+        eprintln!("{}", err);
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> Result<(), Box<dyn Error>> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    let mut counts = Trie::new();
+
+    let mut buf = vec![0; 64 * (1<<10)];
+    let mut node_id = counts.root();
+    loop {
+        let nread = stdin.read(&mut buf)?;
+        if nread == 0 {
+            break;
+        }
+        let buf = &buf[..nread];
+
+        for i in 0..buf.len() {
+            let mut b = buf[i];
+            if b == b' ' || b == b'\n' || b == b'\r' {
+                if !counts.is_root(node_id) {
+                    counts.increment(node_id);
+                    node_id = counts.root();
+                }
+            } else {
+                if b'A' <= b && b <= b'Z' {
+                    b += b'a' - b'A';
+                }
+                node_id = counts.add_child(node_id, b);
+            }
+        }
+    }
+    if !counts.is_root(node_id) {
+        counts.increment(node_id);
+    }
+
+    let mut ordered: Vec<(Vec<u8>, u64)> = counts.frequencies();
+    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+
+    let mut stdout = io::stdout();
+    for (word, count) in ordered {
+        writeln!(stdout, "{} {}", std::str::from_utf8(&word)?, count)?;
+    }
+    Ok(())
+}
+
+const NODE_SIZE: usize = 256;
+
+/// An ID that doubles as an index into a trie's node table. It is
+/// premultiplied, so that given a node ID 'N' and a byte 'b', computing
+/// its child only requires an addition: 'trie.nodes[N + b]'. (The
+/// typical formulation wouldn't premultiply the ID, and thus, you'd need
+/// 'trie.nodes[(N * 256) + b]'.)
+type TrieNodeID = std::num::NonZeroUsize;
+
+/// A trie that stores its nodes contiguously in memory.
+#[derive(Clone, Debug)]
+struct Trie {
+    /// A row-major contiguous allocation of trie nodes.
+    nodes: Vec<Option<TrieNodeID>>,
+    /// A count exists for each node in the trie. For a node ID 'N', one can
+    /// get its count via 'counts[N / 256]'.
+    counts: Vec<u64>,
+}
+
+/// A borrow view of a single trie node. Used for traversing the trie to
+/// collect the words and their frequencies.
+#[derive(Clone, Debug)]
+struct TrieNode<'a> {
+    children: &'a [Option<TrieNodeID>],
+    count: u64,
+}
+
+impl Trie {
+    /// Create a new empty trie.
+    fn new() -> Trie {
+        let mut trie = Trie { nodes: vec![], counts: vec![] };
+        // add dummy node with id==0. This is never used. We explicitly add it
+        // to avoid needing to subtract 1 on every node lookup. The root starts
+        // at id==1.
+        trie.nodes.extend(std::iter::repeat(None).take(256));
+        trie.counts.push(0);
+        trie.alloc_node(); // root node
+        trie
+    }
+
+    /// Return the ID of the root node of this trie.
+    fn root(&self) -> TrieNodeID {
+        TrieNodeID::new(1).unwrap()
+    }
+
+    /// Adds a transition from current_id for the given byte to a child node
+    /// if one doesn't exist. Either way, the corresponding child node ID is
+    /// returned.
+    fn add_child(&mut self, current_id: TrieNodeID, b: u8) -> TrieNodeID {
+        let child = self.child(current_id, b);
+        if child.is_some() {
+            return child.unwrap();
+        }
+        self.alloc_child(current_id, b)
+    }
+
+    fn alloc_child(&mut self, current_id: TrieNodeID, b: u8) -> TrieNodeID {
+        let child = self.alloc_node();
+        self.nodes[current_id.get() + b as usize] = Some(child);
+        child
+    }
+
+    /// Returns the child node ID of the given current node for the given byte.
+    fn child(&self, current_id: TrieNodeID, b: u8) -> Option<TrieNodeID> {
+        self.nodes[current_id.get() + b as usize]
+    }
+
+    /// Allocates a new node in this trie (with all children empty) and returns
+    /// its ID.
+    fn alloc_node(&mut self) -> TrieNodeID {
+        // This is correct since new() allocates space for a dummy node, so
+        // self.counts.len() is always at least 1.
+        let id = TrieNodeID::new(self.counts.len() * NODE_SIZE).unwrap();
+        self.nodes.extend(std::iter::repeat(None).take(256));
+        self.counts.push(0);
+        id
+    }
+
+    fn increment(&mut self, id: TrieNodeID) {
+        self.counts[id.get() / NODE_SIZE] += 1;
+    }
+
+    fn is_root(&self, id: TrieNodeID) -> bool {
+        id.get() == 1
+    }
+
+    fn node<'a>(&'a self, id: TrieNodeID) -> TrieNode<'a> {
+        let count = self.counts[id.get() / NODE_SIZE];
+        let start = id.get();
+        let end = start + NODE_SIZE;
+        TrieNode { children: &self.nodes[start..end], count }
+    }
+
+    fn frequencies(&self) -> Vec<(Vec<u8>, u64)> {
+        struct NodeWithChild {
+            id: TrieNodeID,
+            byte: usize,
+        }
+
+        let byte = self.node(self.root()).next_child(0);
+        let mut stack = vec![NodeWithChild { id: self.root(), byte }];
+        let mut word = vec![];
+        let mut freqs = vec![];
+
+        while let Some(NodeWithChild { id, byte }) = stack.pop() {
+            let node = self.node(id);
+            if byte >= 256 {
+                word.pop();
+                continue;
+            }
+            stack.push(NodeWithChild {
+                id, byte: node.next_child(byte + 1),
+            });
+
+            // This unwrap is correct because we only ever push non-empty
+            // children onto our stack.
+            let child_id = node.children[byte].unwrap();
+            let child = self.node(child_id);
+            word.push(byte as u8);
+            if child.count > 0 {
+                freqs.push((word.clone(), child.count));
+            }
+            stack.push(NodeWithChild {
+                id: child_id,
+                byte: child.next_child(0),
+            });
+        }
+        freqs
+    }
+}
+
+impl<'a> TrieNode<'a> {
+    fn next_child(&self, at_or_after: usize) -> usize {
+        for i in at_or_after..=(u8::MAX as usize) {
+            if self.children[i].is_some() {
+                return i;
+            }
+        }
+        256
+    }
+}

--- a/rust/optimized/Cargo.toml
+++ b/rust/optimized/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "optimized"
+version = "0.1.0"
+authors = ["Andrew Gallant <jamslam@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "countwords"
+path = "main.rs"
+
+[dependencies]
+fxhash = "0.2.1"
+
+[profile.release]
+debug = true

--- a/rust/optimized/main.rs
+++ b/rust/optimized/main.rs
@@ -1,0 +1,89 @@
+// This version is an approximate port of the optimized Go program. Its buffer
+// handling is slightly simpler: we don't bother with dealing with the last
+// newline character. (This may appear to save work, but it only saves work
+// once per 64KB buffer, so is likely negligible. It's just simpler IMO.)
+//
+// There's nothing particularly interesting here other than swapping out std's
+// default hashing algorithm for one that isn't cryptographically secure.
+
+use std::{
+    error::Error,
+    io::{self, Read, Write},
+};
+
+// std uses a cryptographically secure hashing algorithm by default, which is
+// a bit slower. In this particular program, fxhash and fnv seem to perform
+// similarly, with fxhash being a touch faster in my ad hoc benchmarks. If
+// we wanted to really enforce the "no external crate" rule, we could just
+// hand-roll an fnv hash impl ourselves very easily.
+//
+// N.B. This crate brings in a new hashing function. We still use std's hashmap
+// implementation.
+use fxhash::{FxHashMap as HashMap};
+
+fn main() {
+    if let Err(err) = try_main() {
+        eprintln!("{}", err);
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> Result<(), Box<dyn Error>> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    let mut counts: HashMap<Vec<u8>, u64> = HashMap::default();
+    let mut buf = vec![0; 64 * (1<<10)];
+    let mut offset = 0;
+    let mut start = None;
+    loop {
+        let nread = stdin.read(&mut buf[offset..])?;
+        if nread == 0 {
+            if offset > 0 {
+                increment(&mut counts, &buf[..offset+1]);
+            }
+            break;
+        }
+        let buf = &mut buf[..offset+nread];
+
+        for i in (0..buf.len()).skip(offset) {
+            let b = buf[i];
+            if b'A' <= b && b <= b'Z' {
+                buf[i] += b'a' - b'A';
+            }
+            if b == b' ' || b == b'\n' {
+                if let Some(start) = start.take() {
+                    increment(&mut counts, &buf[start..i]);
+                }
+            } else if start.is_none() {
+                start = Some(i);
+            }
+        }
+        if let Some(ref mut start) = start {
+            offset = buf.len() - *start;
+            buf.copy_within(*start.., 0);
+            *start = 0;
+        } else {
+            offset = 0;
+        }
+    }
+
+    let mut ordered: Vec<(Vec<u8>, u64)> = counts.into_iter().collect();
+    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+
+    for (word, count) in ordered {
+        writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
+    }
+    Ok(())
+}
+
+fn increment(counts: &mut HashMap<Vec<u8>, u64>, word: &[u8]) {
+    // using 'counts.entry' would be more idiomatic here, but doing so requires
+    // allocating a new Vec<u8> because of its API. Instead, we do two hash
+    // lookups, but in the exceptionally common case (we see a word we've
+    // already seen), we only do one and without any allocs.
+    if let Some(count) = counts.get_mut(word) {
+        *count += 1;
+        return;
+    }
+    counts.insert(word.to_vec(), 1);
+}

--- a/rust/simple/Cargo.toml
+++ b/rust/simple/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "simple"
+version = "0.1.0"
+authors = ["Andrew Gallant <jamslam@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "countwords"
+path = "main.rs"
+
+[profile.release]
+debug = true

--- a/rust/simple/main.rs
+++ b/rust/simple/main.rs
@@ -1,0 +1,52 @@
+// This version is roughly how I would write this program if someone gave
+// me the problem as an interview challenge and said, "don't worry about
+// performance." One of the main performance problems in this program is
+// the `word.to_lowercase()` function, which results in an allocation. (It
+// also does Unicode case folding, which is unnecessary for this particular
+// challenge. But the simple Go variant does the same, and this is what I
+// would reach for naturally, so I left it in.) However, one needs to allocate
+// anyway to use the `entry` API, even though the common case is that the
+// word already exists in the hash map. The code changes required to use
+// `make_ascii_uppercase` and check if the word is already in the hash map (at
+// the expense of doing another lookup if it isn't) are quite small and lead to
+// a massive performance improvement. Nevertheless, this code is simpler.
+//
+// Other costs, although smaller, are UTF-8 validation and the fact that we're
+// also allocating a new String for each line. (And the fact that we're even
+// worrying about lines at all. The other Rust programs do not.)
+
+use std::{
+    collections::HashMap,
+    error::Error,
+    io::{self, BufRead, Write},
+};
+
+fn main() {
+    // We don't return Result from main because it prints the debug
+    // representation of the error. The code below prints the "display" or
+    // human readable representation of the error.
+    if let Err(err) = try_main() {
+        eprintln!("{}", err);
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> Result<(), Box<dyn Error>> {
+    let stdin = io::stdin();
+    let stdin = io::BufReader::new(stdin.lock());
+    let mut counts: HashMap<String, u64> = HashMap::new();
+    for result in stdin.lines() {
+        let line = result?;
+        for word in line.split_whitespace() {
+            let canon = word.to_lowercase();
+            *counts.entry(canon).or_insert(0) += 1;
+        }
+    }
+
+    let mut ordered: Vec<(String, u64)> = counts.into_iter().collect();
+    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+    for (word, count) in ordered {
+        writeln!(io::stdout(), "{} {}", word, count)?;
+    }
+    Ok(())
+}

--- a/test.sh
+++ b/test.sh
@@ -37,6 +37,11 @@ cargo build --release --manifest-path rust/optimized-trie/Cargo.toml
 ./rust/optimized-trie/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Rust optimized custom hashmap
+cargo build --release --manifest-path rust/optimized-customhashmap/Cargo.toml
+./rust/optimized-customhashmap/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
 echo C++ simple
 g++ -O2 simple.cpp -o simple-cpp
 ./simple-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt

--- a/test.sh
+++ b/test.sh
@@ -27,6 +27,11 @@ cargo build --release --manifest-path rust/simple/Cargo.toml
 ./rust/simple/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Rust optimized
+cargo build --release --manifest-path rust/optimized/Cargo.toml
+./rust/optimized/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
 echo C++ simple
 g++ -O2 simple.cpp -o simple-cpp
 ./simple-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt

--- a/test.sh
+++ b/test.sh
@@ -46,13 +46,17 @@ echo AWK simple
 gawk -f simple.awk <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
-echo AWK optimized
-mawk -f optimized.awk <kjvbible_x10.txt | python3 normalize.py >output.txt
-git diff --exit-code output.txt
+if command -v mawk > /dev/null; then
+  echo AWK optimized
+  mawk -f optimized.awk <kjvbible_x10.txt | python3 normalize.py >output.txt
+  git diff --exit-code output.txt
+fi
 
-echo Forth simple
-../gforth/gforth simple.fs <kjvbible_x10.txt | python3 normalize.py >output.txt
-git diff --exit-code output.txt
+if [ -x ../gforth/gforth ]; then
+  echo Forth simple
+  ../gforth/gforth simple.fs <kjvbible_x10.txt | python3 normalize.py >output.txt
+  git diff --exit-code output.txt
+fi
 
 echo Unix shell
 bash simple.sh <kjvbible_x10.txt | awk '{ print $2, $1 }' | python3 normalize.py >output.txt

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,11 @@ cargo build --release --manifest-path rust/optimized/Cargo.toml
 ./rust/optimized/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Rust optimized trie
+cargo build --release --manifest-path rust/optimized-trie/Cargo.toml
+./rust/optimized-trie/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
 echo C++ simple
 g++ -O2 simple.cpp -o simple-cpp
 ./simple-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,11 @@ go build -o optimized-go optimized.go
 ./optimized-go <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Rust simple
+cargo build --release --manifest-path rust/simple/Cargo.toml
+./rust/simple/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
 echo C++ simple
 g++ -O2 simple.cpp -o simple-cpp
 ./simple-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt

--- a/test.sh
+++ b/test.sh
@@ -42,6 +42,11 @@ cargo build --release --manifest-path rust/optimized-customhashmap/Cargo.toml
 ./rust/optimized-customhashmap/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Rust bonus '(Unicode word segmentation)'
+cargo build --release --manifest-path rust/bonus/Cargo.toml
+./rust/bonus/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
+# We don't test its output since it uses a different segmenter.
+
 echo C++ simple
 g++ -O2 simple.cpp -o simple-cpp
 ./simple-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt


### PR DESCRIPTION
So I kind of ran away with this a bit. I wrote 5 different Rust programs. If you only want the "simple" and "optimized" versions, then that's OK, but I think the others are interesting:

* `simple` and `optimized` roughly mirror the Go programs by the same name.
* `optimized-customhashmap` is an approximate port of your optimized C program.
* `optimized-trie` was an experiment of mine to drop the use of a hash table and instead use a trie. Ultimately, this ended up being slower. Maybe twice as slow.
* `bonus` shows a Rust program that does full Unicode aware word segmentation. It's about as fast as the Rust and Go `simple` variants. It's a nice bonus challenge, because I wonder what this program would like ported to other languages. :-)

Here are some benchmarks I ran locally with `hyperfine`. Not that the timings in particular are too important, but it's a nice sanity check. If you get dramatically different results, then maybe it's worth looking more carefully.

```
$ hyperfine './rust/simple/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: ./rust/simple/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):      1.023 s ±  0.050 s    [User: 1.012 s, System: 0.010 s]
  Range (min … max):    0.949 s …  1.076 s    10 runs

$ hyperfine './rust/optimized/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: ./rust/optimized/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):     270.2 ms ±   6.9 ms    [User: 263.1 ms, System: 6.9 ms]
  Range (min … max):   261.5 ms … 282.0 ms    11 runs

$ hyperfine './rust/optimized-trie/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: ./rust/optimized-trie/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):     338.0 ms ±   5.8 ms    [User: 291.6 ms, System: 45.0 ms]
  Range (min … max):   324.2 ms … 343.6 ms    10 runs

$ hyperfine './rust/optimized-customhashmap/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: ./rust/optimized-customhashmap/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):     208.0 ms ±   7.3 ms    [User: 197.6 ms, System: 10.2 ms]
  Range (min … max):   186.4 ms … 216.1 ms    15 runs

$ hyperfine './rust/bonus/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: ./rust/bonus/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):      1.125 s ±  0.042 s    [User: 1.114 s, System: 0.010 s]
  Range (min … max):    1.072 s …  1.183 s    10 runs

$ hyperfine './simple-go < kjvbible_x10.txt'
Benchmark #1: ./simple-go < kjvbible_x10.txt
  Time (mean ± σ):     900.0 ms ±  35.4 ms    [User: 954.9 ms, System: 34.4 ms]
  Range (min … max):   841.7 ms … 948.3 ms    10 runs

$ hyperfine './optimized-go < kjvbible_x10.txt'
Benchmark #1: ./optimized-go < kjvbible_x10.txt
  Time (mean ± σ):     299.0 ms ±  25.9 ms    [User: 288.0 ms, System: 16.7 ms]
  Range (min … max):   265.1 ms … 361.3 ms    10 runs

$ hyperfine './simple-c < kjvbible_x10.txt'
Benchmark #1: ./simple-c < kjvbible_x10.txt
  Time (mean ± σ):     737.4 ms ±  30.9 ms    [User: 725.9 ms, System: 11.0 ms]
  Range (min … max):   690.1 ms … 779.8 ms    10 runs

$ hyperfine './optimized-c < kjvbible_x10.txt'
Benchmark #1: ./optimized-c < kjvbible_x10.txt
  Time (mean ± σ):     179.8 ms ±   4.0 ms    [User: 174.9 ms, System: 4.6 ms]
  Range (min … max):   166.5 ms … 185.0 ms    17 runs

$ hyperfine './optimized-c-llvm < kjvbible_x10.txt'
Benchmark #1: ./optimized-c-llvm < kjvbible_x10.txt
  Time (mean ± σ):     185.4 ms ±   7.4 ms    [User: 175.9 ms, System: 9.3 ms]
  Range (min … max):   167.4 ms … 191.8 ms    16 runs
```