### PR TITLE
Rust avoid rebuffering Stdin

### DIFF
--- a/rust/bonus/main.rs
+++ b/rust/bonus/main.rs
@@ -38,7 +38,7 @@ fn main() {
 
 fn try_main() -> anyhow::Result<()> {
     let stdin = io::stdin();
-    let stdin = io::BufReader::new(stdin.lock());
+    let stdin = stdin.lock();
 
     let mut counts: HashMap<BString, u64> = HashMap::default();
     let mut buf = BString::from(vec![]);

--- a/rust/simple/main.rs
+++ b/rust/simple/main.rs
@@ -33,7 +33,7 @@ fn main() {
 
 fn try_main() -> Result<(), Box<dyn Error>> {
     let stdin = io::stdin();
-    let stdin = io::BufReader::new(stdin.lock());
+    let stdin = stdin.lock();
     let mut counts: HashMap<String, u64> = HashMap::new();
     for result in stdin.lines() {
         let line = result?;


### PR DESCRIPTION
cc @BurntSushi 

`StdinLock` already implements `BufRead`

```
> hyperfine 'rust/simple/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: rust/simple/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):      1.151 s ±  0.020 s    [User: 1.138 s, System: 0.012 s]
  Range (min … max):    1.123 s …  1.179 s    10 runs
 
> hyperfine 'rust/simple/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: rust/simple/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):      1.150 s ±  0.019 s    [User: 1.137 s, System: 0.012 s]
  Range (min … max):    1.116 s …  1.175 s    10 runs
 
> hyperfine 'rust/bonus/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: rust/bonus/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):      1.308 s ±  0.066 s    [User: 1.299 s, System: 0.008 s]
  Range (min … max):    1.216 s …  1.395 s    10 runs
 
> hyperfine 'rust/bonus/target/release/countwords < kjvbible_x10.txt'
Benchmark #1: rust/bonus/target/release/countwords < kjvbible_x10.txt
  Time (mean ± σ):      1.252 s ±  0.025 s    [User: 1.241 s, System: 0.010 s]
  Range (min … max):    1.220 s …  1.291 s    10 runs
 
> hyperfine './simple-c < kjvbible_x10.txt'
Benchmark #1: ./simple-c < kjvbible_x10.txt
  Time (mean ± σ):     855.2 ms ±  31.3 ms    [User: 845.1 ms, System: 8.9 ms]
  Range (min … max):   820.5 ms … 927.1 ms    10 runs
 
```

See https://github.com/rust-lang/rust-clippy/issues/6755
https://users.rust-lang.org/t/correct-way-for-taking-large-input-from-keyboard/55304/11