### PR TITLE
Optimize simple.cs

### DIFF
--- a/simple.cs
+++ b/simple.cs
@@ -22,9 +22,11 @@ class Program
             }
         }
         var ordered = counts.OrderByDescending(pair => pair.Value);
+        StringBuilder stringBuilder = new StringBuilder();
         foreach (var entry in ordered)
         {
-            Console.WriteLine("{0} {1}", entry.Key, entry.Value);
+            stringBuilder.AppendLine($"{entry.Key} {entry.Value}");
         }
+        Console.Write(stringBuilder.ToString());
     }
 }


### PR DESCRIPTION
The largest portion of the performance cost of this method is strictly using Console.ReadLine and Console.WriteLine (in particular Console.WriteLine 32187 times)

Instead, use a StringBuilder to combine the messages and call Console.Write once at the end.

In my testing, making the above change cut the average execution from 2.1 seconds to 0.5 seconds.

Even still, the largest portion of the performance cost is using Console. The word counting in isolation executes in 0.1 seconds on my machine.

Anyway, interesting project and keep up the good work.