### PR TITLE
Add Julia simple version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ Thanks to these contributors for additional language versions:
 * Ruby: [Bill Mill](https://github.com/llimllib), with input from [Niklas](https://github.com/nhh)
 * JavaScript: [Dani Biró](https://github.com/Daninet)
 * Nim: [csterritt](https://github.com/csterritt) and [euantorano](https://github.com/euantorano)
+* Julia: [Alessandro Melis](https://github.com/alemelis)
 
 See other versions [on Rosetta Code](https://rosettacode.org/wiki/Word_frequency).

--- a/benchmark.py
+++ b/benchmark.py
@@ -32,6 +32,7 @@ programs = [
     ('AWK', 'gawk -f simple.awk', 'mawk -f optimized.awk', 'optimized uses `mawk`'),
     ('Forth', '../gforth/gforth-fast simple.fs', '../gforth/gforth-fast optimized.fs', ''),
     ('Shell', 'bash simple.sh', 'bash optimized.sh', 'optimized does `LC_ALL=C sort -S 2G`'),
+    ('Julia', 'julia simple.jl', '', ''),
 ]
 
 times = []

--- a/benchmark.py
+++ b/benchmark.py
@@ -33,7 +33,7 @@ programs = [
     ('AWK', 'gawk -f simple.awk', 'mawk -f optimized.awk', 'optimized uses `mawk`'),
     ('Forth', '../gforth/gforth-fast simple.fs', '../gforth/gforth-fast optimized.fs', ''),
     ('Shell', 'bash simple.sh', 'bash optimized.sh', 'optimized does `LC_ALL=C sort -S 2G`'),
-    ('Julia', 'julia simple.jl', '', ''),
+    ('Julia', 'julia simple.jl', None, 'by Alessandro Melis'),
     ('Perl', 'perl simple.pl', None, 'by Charles Randall'),
     ('JavaScript', 'node ./simple', 'node ./optimized', 'by Dani Biro'),
     ('Nim', './simple-nim', None, 'by csterritt and euantorano'),

--- a/simple.jl
+++ b/simple.jl
@@ -1,10 +1,11 @@
-function wc(lines, counter=Dict())
-    for line in lines, word in lowercase.(split(line))
-        counter[word] = get!(counter, word, 0) + 1
+function wc(io, counter=Dict{String,Int}())
+    for line in eachline(io), word in split(line)
+        lword = lowercase(word)
+        counter[lword] = get(counter, lword, 0) + 1
     end
     counter
 end
 
-sortdict(counter) = sort(collect(counter), by=x->x[2], rev=true)
+sortdict(counter) = sort!(collect(counter), by=x->x[2], rev=true)
 
-wc(readlines()) |> sortdict .|> kv->println(kv[1], " ", kv[2]) 
+wc(stdin) |> sortdict .|> kv->println(kv[1], " ", kv[2]) 

--- a/simple.jl
+++ b/simple.jl
@@ -1,0 +1,10 @@
+function wc(path, counter=Dict())
+    for line in eachline(path), word in split(line)
+        counter[word] = get(counter, word, 0) + 1
+    end
+    counter
+end
+
+sortdict(counter) = sort(collect(counter), by=x->x[2], rev=true)
+
+wc(ARGS[1]) |> sortdict .|> kv->println(kv[1], " ", kv[2]) 

--- a/simple.jl
+++ b/simple.jl
@@ -1,6 +1,6 @@
 function wc(lines, counter=Dict())
     for line in lines, word in split(line)
-        get!(counter, word, 0) + 1
+        get!(counter, lowercase(word), 0) + 1
     end
     counter
 end

--- a/simple.jl
+++ b/simple.jl
@@ -1,10 +1,10 @@
-function wc(path, counter=Dict())
-    for line in eachline(path), word in split(line)
-        counter[word] = get(counter, word, 0) + 1
+function wc(lines, counter=Dict())
+    for line in lines, word in split(line)
+        get!(counter, word, 0) + 1
     end
     counter
 end
 
 sortdict(counter) = sort(collect(counter), by=x->x[2], rev=true)
 
-wc(ARGS[1]) |> sortdict .|> kv->println(kv[1], " ", kv[2]) 
+wc(readlines()) |> sortdict .|> kv->println(kv[1], " ", kv[2]) 

--- a/simple.jl
+++ b/simple.jl
@@ -1,6 +1,6 @@
 function wc(lines, counter=Dict())
-    for line in lines, word in split(line)
-        get!(counter, lowercase(word), 0) + 1
+    for line in lines, word in lowercase.(split(line))
+        counter[word] = get!(counter, word, 0) + 1
     end
     counter
 end

--- a/test.sh
+++ b/test.sh
@@ -100,3 +100,6 @@ csc -optimize -out:simple-cs simple.cs
 chmod +x simple-cs
 ./simple-cs <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
+
+echo Julia simple
+julia simple.jl kjvbible_x10.txt | python3 normalize.py >output.txt

--- a/test.sh
+++ b/test.sh
@@ -102,4 +102,4 @@ chmod +x simple-cs
 git diff --exit-code output.txt
 
 echo Julia simple
-julia simple.jl kjvbible_x10.txt | python3 normalize.py >output.txt
+julia simple.jl <kjvbible_x10.txt | python3 normalize.py >output.txt


### PR DESCRIPTION
here's a benchmark not including Julia startup overhead

```
julia> @benchmark wc(readlines("kjvbible_x10.txt")) |> sortdict
BenchmarkTools.Trial: 
  memory estimate:  1.57 GiB
  allocs estimate:  29217782
  --------------
  minimum time:     3.387 s (6.13% GC)
  median time:      3.419 s (7.87% GC)
  mean time:        3.419 s (7.87% GC)
  maximum time:     3.451 s (9.57% GC)
  --------------
  samples:          2
  evals/sample:     1
```

discussion here
https://discourse.julialang.org/t/count-words-challenge/57221/5