### PR TITLE
Fixed printing of non null terminated char array

### DIFF
--- a/optimized.c
+++ b/optimized.c
@@ -140,7 +140,8 @@ int main() {
     }
     qsort(ordered, num_unique, sizeof(count), cmp_count);
     for (int i=0; i<num_unique; i++) {
-        printf("%s %d\n", ordered[i].word, ordered[i].count);
+        printf("%.*s %d\n",
+                ordered[i].word_len, ordered[i].word, ordered[i].count);
     }
 
     return 0;


### PR DESCRIPTION
The ordered[i].word in c optimized version isn't null terminated, printing it with %s causes ub.