### PR TITLE
Optimize the C++ version somewhat

### DIFF
--- a/optimized.cpp
+++ b/optimized.cpp
@@ -1,26 +1,71 @@
-// NOTE: this isn't really optimized C++ (as C++ is not my forte).
-// See the C version for more optimization.
-
 #include <algorithm>
 #include <cctype>
-#include <iostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <iostream>
+#include <cassert>
 
-int main() {
-    std::ios::sync_with_stdio(false);
+#ifdef USE_ABSEIL
+#include <absl/container/flat_hash_map.h>
+typedef absl::flat_hash_map<std::string, int> WordMap;
+#else
+typedef std::unordered_map<std::string, int> WordMap;
+#endif
 
+size_t split_buffer(WordMap &counts, char *buf, size_t data_size) {
+    size_t i=0;
     std::string word;
-    std::unordered_map<std::string, int> counts;
-    while (std::cin >> word) {
-        std::transform(word.begin(), word.end(), word.begin(),
-            [](unsigned char c){ return std::tolower(c); });
-        counts[word]++;
+    while(true) {
+        while(i<data_size && (buf[i] == ' ' || buf[i] == '\n')) {
+            ++i;
+        }
+        if(i == data_size) {
+            // Nothing but spaces.
+            break;
+        }
+        size_t word_start = i;
+        while(i<data_size && (buf[i] != ' ' && buf[i] != '\n')) {
+            if(buf[i] >= 'A' && buf[i] <= 'Z') {
+                buf[i] += 'a'-'A';
+            }
+            ++i;
+        }
+        if(i == data_size) {
+            // Reached the end of the buffer. Do not use this
+            // as the word may continue in the next data block;
+            return word_start;
+        }
+        size_t word_end = i;
+        word.clear();
+        word.append(buf + word_start, word_end - word_start);
+        ++counts[word];
     }
-    if (std::cin.bad()) {
-        std::cerr << "error reading stdin\n";
-        return 1;
+    return i;
+}
+
+int main(int argc, char **argv) {
+    WordMap counts;
+    counts.reserve(10000);
+
+    const int bufsize = 8*1024;
+    char buf[bufsize];
+    int i=0;
+    FILE *f;
+    if(argc == 2) {
+        f = fopen(argv[1], "r");
+    } else {
+        f = stdin;
+    }
+    while (true) {
+        size_t num_read = fread(buf+i, 1, bufsize-i, f);
+        if (num_read == 0) {
+            break;
+        }
+        size_t data_size = i + num_read;
+        auto bytes_consumed = split_buffer(counts, buf, data_size);
+        std::copy(buf+bytes_consumed, buf+data_size, buf);
+        i = data_size - bytes_consumed;
     }
 
     std::vector<std::pair<std::string, int>> ordered(counts.begin(),

--- a/test.sh
+++ b/test.sh
@@ -53,7 +53,7 @@ g++ -O2 simple.cpp -o simple-cpp
 git diff --exit-code output.txt
 
 echo C++ optimized
-g++ -O2 optimized.cpp -o optimized-cpp
+g++ -O2 -std=c++17 optimized.cpp -o optimized-cpp
 ./optimized-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 


### PR DESCRIPTION
Here is an optimized version of the C++ code. The main reason it was slow was the same as for C: the standard library functions for parsing data are fairly slow.

I also updated the code to optionally use Abseil's fast hash map, as the one in the standard library is unfortunately known to be slow. Abseil is a bit of a pain to use as a dependency so it can't be used in the test directly as it just compiles things with a single `g++` invocation.

The timings for optimized builds on my machine are as follows:

- C: 0.15s
- C++: 0.37s
- C++ with Abseil: 0.29s
- C++ with Abseil and LTO: 0.25s
- C++ with Abseil and Clang: 0.24s

 I did not try Clang + LTO because the self-built Clang trunk I had was wonky for some reason.