### PR TITLE
Add a target for C++ with profile guided optimisation (autoPGO)

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -27,6 +27,7 @@ programs = [
     ('Rust A', './rust/simple/target/release/countwords', './rust/optimized/target/release/countwords', 'by Andrew Gallant'),
     ('Rust B', './rust/bonus/target/release/countwords', './rust/optimized-customhashmap/target/release/countwords', 'also by Andrew: bonus and custom hash'),
     ('C++', './simple-cpp', './optimized-cpp', 'optimized by Jussi Pakkanen'),
+    ('C++ (autoPGO)', './optimized-pgo-cpp', None, 'by Adev'),
     ('Python', 'python3 simple.py', 'python3 optimized.py', ''),
     ('Ruby', 'ruby simple.rb', 'ruby optimized.rb', 'by Bill Mill'),
     ('C#', './csharp/simple/bin/Release/net5.0/simple', './csharp/optimized/bin/Release/net5.0/optimized', 'by John Taylor and Yuriy Ostapenko'),

--- a/benchmark.py
+++ b/benchmark.py
@@ -5,6 +5,7 @@
 
 import subprocess
 import time
+import math
 
 NUM_RUNS = 5
 INPUT_FILENAME = 'kjvbible_x10.txt'
@@ -27,7 +28,7 @@ programs = [
     ('Rust A', './rust/simple/target/release/countwords', './rust/optimized/target/release/countwords', 'by Andrew Gallant'),
     ('Rust B', './rust/bonus/target/release/countwords', './rust/optimized-customhashmap/target/release/countwords', 'also by Andrew: bonus and custom hash'),
     ('C++', './simple-cpp', './optimized-cpp', 'optimized by Jussi Pakkanen'),
-    ('C++ (autoPGO)', './optimized-pgo-cpp', None, 'by Adev'),
+    ('C++ (autoPGO)', None, './optimized-pgo-cpp', 'by Adev'),
     ('Python', 'python3 simple.py', 'python3 optimized.py', ''),
     ('Ruby', 'ruby simple.rb', 'ruby optimized.rb', 'by Bill Mill'),
     ('C#', './csharp/simple/bin/Release/net5.0/simple', './csharp/optimized/bin/Release/net5.0/optimized', 'by John Taylor and Yuriy Ostapenko'),
@@ -49,7 +50,7 @@ times = []
 for program in programs:
     lang, simple, optimized, _ = program
     print('Timing', lang, end=' ', flush=True)
-    simple_time = time_run(simple)
+    simple_time = time_run(simple) if simple else math.nan
     optimized_time = time_run(optimized) if optimized else None
     print('{:.2f} {:.2f}'.format(simple_time, optimized_time or 0))
     times.append((program, simple_time, optimized_time))

--- a/test.sh
+++ b/test.sh
@@ -61,9 +61,19 @@ g++ -O2 simple.cpp -o simple-cpp
 git diff --exit-code output.txt
 
 echo C++ optimized
-g++ -O2 -DNDEBUG  -std=c++17 optimized.cpp -o optimized-cpp
+g++ -static -O2  -DNDEBUG  -flto -std=c++17 optimized.cpp -o optimized-cpp
 ./optimized-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
+
+echo "C++ (AutoPGO)"
+# compile and run once for profile generation
+g++ -static -O2  -DNDEBUG  -flto -std=c++17 -fprofile-generate=profile-cpp  optimized.cpp -o optimized-pgo-cpp
+./optimized-pgo-cpp <kjvbible_x10.txt > /dev/null
+# recompile with profile info
+g++ -static -O2  -DNDEBUG  -flto -std=c++17 -fprofile-use=profile-cpp  optimized.cpp -o optimized-pgo-cpp
+./optimized-pgo-cpp <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
 
 echo C simple
 gcc -O2 simple.c -o simple-c

--- a/test.sh
+++ b/test.sh
@@ -67,6 +67,7 @@ git diff --exit-code output.txt
 
 echo "C++ (AutoPGO)"
 # compile and run once for profile generation
+rm -f profile-cpp/*
 g++ -static -O2  -DNDEBUG  -flto -std=c++17 -fprofile-generate=profile-cpp  optimized.cpp -o optimized-pgo-cpp
 ./optimized-pgo-cpp <kjvbible_x10.txt > /dev/null
 # recompile with profile info


### PR DESCRIPTION
Add a C++ target with profile guided optimisation enabled

Reduce significantly execution time ( < 0.29s locally )

```
Language      | Simple | Optimized | Notes
------------- | ------ | --------- | -----
Forth         |   0.00 |      0.00 | 
`grep`        |   0.04 |      0.04 | `grep` baseline; optimized sets `LC_ALL=C`
`wc -w`       |   0.24 |      0.17 | `wc` baseline; optimized sets `LC_ALL=C`
C++ (autoPGO) |   0.29 |           | by Adev
C             |   0.80 |      0.35 | 
Nim           |   0.83 |           | by csterritt and euantorano
Go            |   1.12 |      0.36 | 
Rust A        |   1.20 |      0.31 | by Andrew Gallant
Rust B        |   1.24 |      0.28 | also by Andrew: bonus and custom hash
C++           |   1.44 |      0.35 | optimized by Jussi Pakkanen
Python        |   1.71 |      1.06 | 
Perl          |   1.72 |           | by Charles Randall
JavaScript    |   2.44 |      1.81 | by Dani Biro
Ruby          |   2.57 |      2.02 | by Bill Mill
AWK           |   2.90 |      0.94 | optimized uses `mawk`
Julia         |   3.53 |           | by Alessandro Melis
C#            |   3.76 |           | original by John Taylor
Shell         |  12.48 |      1.56 | optimized does `LC_ALL=C sort -S 2G`
```