### PR TITLE
Rust minor optimizations

### DIFF
--- a/rust/bonus/main.rs
+++ b/rust/bonus/main.rs
@@ -53,9 +53,10 @@ fn try_main() -> anyhow::Result<()> {
         Ok(true)
     })?;
 
-    let mut ordered: Vec<(BString, u64)> = counts.into_iter().collect();
-    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
-    for (word, count) in ordered {
+    let mut ordered: Vec<_> = counts.into_iter().collect();
+    ordered.sort_unstable_by_key(|&(_, count)| count);
+
+    for (word, count) in ordered.into_iter().rev() {
         writeln!(io::stdout(), "{} {}", word, count)?;
     }
     Ok(())

--- a/rust/optimized-customhashmap/main.rs
+++ b/rust/optimized-customhashmap/main.rs
@@ -49,7 +49,7 @@ fn try_main() -> Result<(), Box<dyn Error>> {
                 }
             } else {
                 // 0x20 (6th bit) is the only different bit between lowercase and uppercase
-                buf[i] |= 0x20;
+                buf[i] |= (buf[i].is_ascii_uppercase() as u8) << 5;
                 if start.is_none() {
                     start = Some(i);
                 }

--- a/rust/optimized-customhashmap/main.rs
+++ b/rust/optimized-customhashmap/main.rs
@@ -67,9 +67,9 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut ordered = counts.into_counts();
-    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+    ordered.sort_unstable_by_key(|&(_, count)| count);
 
-    for (word, count) in ordered {
+    for (word, count) in ordered.into_iter().rev() {
         writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
     }
     Ok(())

--- a/rust/optimized-customhashmap/main.rs
+++ b/rust/optimized-customhashmap/main.rs
@@ -48,9 +48,8 @@ fn try_main() -> Result<(), Box<dyn Error>> {
                     hash = FNV_OFFSET;
                 }
             } else {
-                if b'A' <= b && b <= b'Z' {
-                    buf[i] += b'a' - b'A';
-                }
+                // 0x20 (6th bit) is the only different bit between lowercase and uppercase
+                buf[i] |= 0x20;
                 if start.is_none() {
                     start = Some(i);
                 }

--- a/rust/optimized-trie/main.rs
+++ b/rust/optimized-trie/main.rs
@@ -64,11 +64,10 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut ordered = counts.frequencies();
-    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+    ordered.sort_unstable_by_key(|&(_, count)| count);
 
-    let mut stdout = io::stdout();
-    for (word, count) in ordered {
-        writeln!(stdout, "{} {}", std::str::from_utf8(&word)?, count)?;
+    for (word, count) in ordered.into_iter().rev() {
+        writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
     }
     Ok(())
 }

--- a/rust/optimized/main.rs
+++ b/rust/optimized/main.rs
@@ -67,10 +67,10 @@ fn try_main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    let mut ordered: Vec<(Vec<u8>, u64)> = counts.into_iter().collect();
-    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
+    let mut ordered: Vec<_> = counts.into_iter().collect();
+    ordered.sort_unstable_by_key(|&(_, count)| count);
 
-    for (word, count) in ordered {
+    for (word, count) in ordered.into_iter().rev() {
         writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
     }
     Ok(())

--- a/rust/simple/main.rs
+++ b/rust/simple/main.rs
@@ -44,7 +44,7 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     }
 
     let mut ordered: Vec<_> = counts.into_iter().collect();
-    ordered.sort_unstable_by_key(|&(_, count)| count);
+    ordered.sort_by_key(|&(_, count)| count);
 
     for (word, count) in ordered.into_iter().rev() {
         writeln!(io::stdout(), "{} {}", word, count)?;

--- a/rust/simple/main.rs
+++ b/rust/simple/main.rs
@@ -32,10 +32,14 @@ fn main() {
 }
 
 fn try_main() -> Result<(), Box<dyn Error>> {
+    let stdin = io::stdin();
+    let stdin = stdin.lock();
     let mut counts: HashMap<String, u64> = HashMap::new();
-    for line in io::stdin().lock().lines() {
-        for word in line?.split_whitespace() {
-            *counts.entry(word.to_lowercase()).or_insert(0) += 1;
+    for result in stdin.lines() {
+        let line = result?;
+        for word in line.split_whitespace() {
+            let canon = word.to_lowercase();
+            *counts.entry(canon).or_insert(0) += 1;
         }
     }
 

--- a/rust/simple/main.rs
+++ b/rust/simple/main.rs
@@ -43,9 +43,10 @@ fn try_main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    let mut ordered: Vec<(String, u64)> = counts.into_iter().collect();
-    ordered.sort_by(|&(_, cnt1), &(_, cnt2)| cnt1.cmp(&cnt2).reverse());
-    for (word, count) in ordered {
+    let mut ordered: Vec<_> = counts.into_iter().collect();
+    ordered.sort_unstable_by_key(|&(_, count)| count);
+
+    for (word, count) in ordered.into_iter().rev() {
         writeln!(io::stdout(), "{} {}", word, count)?;
     }
     Ok(())

--- a/rust/simple/main.rs
+++ b/rust/simple/main.rs
@@ -32,14 +32,10 @@ fn main() {
 }
 
 fn try_main() -> Result<(), Box<dyn Error>> {
-    let stdin = io::stdin();
-    let stdin = stdin.lock();
     let mut counts: HashMap<String, u64> = HashMap::new();
-    for result in stdin.lines() {
-        let line = result?;
-        for word in line.split_whitespace() {
-            let canon = word.to_lowercase();
-            *counts.entry(canon).or_insert(0) += 1;
+    for line in io::stdin().lock().lines() {
+        for word in line?.split_whitespace() {
+            *counts.entry(word.to_lowercase()).or_insert(0) += 1;
         }
     }
 


### PR DESCRIPTION
cc @BurntSushi

I have made some small optimizations which slightly improve the performance on my machine:

Before:
```
Language      | Simple | Optimized | Notes
------------- | ------ | --------- | -----
`grep`        |   0.05 |      0.05 | `grep` baseline; optimized sets `LC_ALL=C`
`wc -w`       |   0.53 |      0.23 | `wc` baseline; optimized sets `LC_ALL=C`
Rust A        |   1.55 |      0.38 | by Andrew Gallant
Rust B        |   1.62 |      0.31 | also by Andrew: bonus and custom hash
```

After:
```
Language      | Simple | Optimized | Notes
------------- | ------ | --------- | -----
`grep`        |   0.05 |      0.05 | `grep` baseline; optimized sets `LC_ALL=C`
`wc -w`       |   0.54 |      0.23 | `wc` baseline; optimized sets `LC_ALL=C`
Rust A        |   1.52 |      0.38 | by Andrew Gallant
Rust B        |   1.61 |      0.29 | also by Andrew: bonus and custom hash
```