### PR TITLE
Add Raku simple/optmized ; test.sh and benchmark.py edited for Raku

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -43,6 +43,7 @@ programs = [
     ('OCaml', './simple-ml', None, 'by Nate Dobbins'),
     ('Kotlin', 'java -jar simple-kotlin.jar', None, 'by Kazik Pogoda'),
     ('Lua', 'luajit simple.lua', 'luajit optimized.lua', 'by themadsens; runs under luajit'),
+    ('Raku', 'raku simple.raku', 'raku optimized.raku', 'by notagoodidea'),
 ]
 
 times = []

--- a/optimized.raku
+++ b/optimized.raku
@@ -1,0 +1,9 @@
+my %counts is default(0);
+for open($*IN, :enc<ascii>).lines(:close) {
+  for .lc.words -> \w {
+    %counts.AT-KEY(w) == 0 ?? %counts.STORE_AT_KEY(w, 1) !! ++%counts.AT-KEY(w)
+  }
+}
+# From codesections on SO : https://stackoverflow.com/a/66500447
+sub my-reverse(\a, \b) { a.value > b.value ?? False !! True }
+%counts.sort(&my-reverse).fmt('%s',"\n").print;

--- a/simple.raku
+++ b/simple.raku
@@ -1,0 +1,3 @@
+my %counts is BagHash;
+%counts.add($_.lc.words) for $*IN.lines;
+.put for %counts.sort(*.value).reverse;

--- a/test.sh
+++ b/test.sh
@@ -189,3 +189,12 @@ echo Kotlin simple JVM
 kotlinc simple.kt -no-reflect -include-runtime -jvm-target 14 -language-version 1.4 -d simple-kotlin.jar
 java -jar simple-kotlin.jar <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
+
+echo Raku simple
+raku simple.raku <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
+echo Raku optimized
+raku optimized.raku <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+


### PR DESCRIPTION
A simple and optimized version for Raku. On my computer (i56200u, 8Go, Fedora 33, Rakudo 2021.02) is slow with the simple version around ~30s and the optimized ~16s. Maybe it is a bit too slow to be added to the benchmark script.

The optimized one do not drop to [nqp](https://github.com/Raku/nqp).