### PR TITLE
Use bump allocator for keys

### DIFF
--- a/rust/optimized/Cargo.toml
+++ b/rust/optimized/Cargo.toml
@@ -9,6 +9,7 @@ name = "countwords"
 path = "main.rs"
 
 [dependencies]
+bumpalo = "3.6.1"
 fxhash = "0.2.1"
 
 [profile.release]

--- a/rust/optimized/main.rs
+++ b/rust/optimized/main.rs
@@ -17,6 +17,7 @@ use std::io::{self, BufWriter, Read, Write};
 //
 // N.B. This crate brings in a new hashing function. We still use std's hashmap
 // implementation.
+use bumpalo::Bump;
 use fxhash::FxHashMap as HashMap;
 
 fn main() {
@@ -69,8 +70,10 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     let mut ordered: Vec<_> = counts.into_iter().collect();
     ordered.sort_unstable_by_key(|&(_, count)| count);
 
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::new(stdout.lock());
     for (word, count) in ordered.into_iter().rev() {
-        writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
+        writeln!(stdout, "{} {}", std::str::from_utf8(&word)?, count)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Should not reallocate on every keys

Before

```
> hyperfine 'target/release/countwords < ../../kjvbible.txt'
Benchmark #1: target/release/countwords < ../../kjvbible.txt
  Time (mean ± σ):      60.7 ms ±  11.8 ms    [User: 53.3 ms, System: 7.5 ms]
  Range (min … max):    43.9 ms …  74.8 ms    44 runs
```

After keys arena

```
> hyperfine 'target/release/countwords < ../../kjvbible.txt'
Benchmark #1: target/release/countwords < ../../kjvbible.txt
  Time (mean ± σ):      47.7 ms ±  11.5 ms    [User: 41.2 ms, System: 6.5 ms]
  Range (min … max):    37.4 ms …  70.0 ms    48 runs
 ```

After bufwriter

```
> hyperfine 'target/release/countwords < ../../kjvbible.txt'
Benchmark #1: target/release/countwords < ../../kjvbible.txt
  Time (mean ± σ):      46.7 ms ±  13.5 ms    [User: 43.4 ms, System: 3.3 ms]
  Range (min … max):    29.9 ms …  63.9 ms    43 runs
```

Follow up of https://github.com/benhoyt/countwords/pull/1#issuecomment-799584798
cc @BurntSushi