### PR TITLE
Use LDC compiler for D benchmark

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -165,12 +165,12 @@ node ./optimized <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
 echo DLang simple
-dmd -release -O -inline -of=simple-d simple.d
+ldc2 -release -O3 -of=simple-d simple.d
 ./simple-d <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
 echo DLang optimized
-dmd -release -O -inline -of=optimized-d optimized.d
+ldc2 -release -O3 -of=optimized-d optimized.d
 ./optimized-d <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 


### PR DESCRIPTION
Hello

LDC is the recommended compiler for release mode / benchmarks

DMD is recommended for fast compile time for development purposes, not suited for benchmarks

---

optimized.d

DMD
```
Exit code      : 0
Elapsed time   : 0.22
Kernel time    : 0.02 (7.1%)
User time      : 0.20 (92.3%)
page fault #   : 2984
Working set    : 11344 KB
Paged pool     : 123 KB
Non-paged pool : 9 KB
Page file size : 14992 KB
```

LDC
```
Exit code      : 0
Elapsed time   : 0.15
Kernel time    : 0.03 (20.2%)
User time      : 0.12 (80.8%)
page fault #   : 3644
Working set    : 14164 KB
Paged pool     : 51 KB
Non-paged pool : 6 KB
Page file size : 14504 KB
```