### PR TITLE
Add simple and optimized J implementations

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -44,6 +44,7 @@ programs = [
     ('Kotlin', 'java -jar simple-kotlin.jar', None, 'by Kazik Pogoda'),
     ('Lua', 'luajit simple.lua', 'luajit optimized.lua', 'by themadsens; runs under luajit'),
     ('Zig', './simple-zig', None, 'by ifreund and matu3ba'),
+    ('J', './simple-j.ijs', './optimized-j.ijs', 'by jrfondren'),
 ]
 
 times = []

--- a/optimized-j.ijs
+++ b/optimized-j.ijs
@@ -1,0 +1,12 @@
+#! /usr/bin/env ijconsole
+require 'format/printf'
+9!:37 ] 0 _ 0 _
+m =: 256 $ 0
+m =: 1 (,(a.i.'Aa')+/i.26) }m
+s =: _2]\"1 }.".;._2 (0 : 0)
+'  X   L  ']0
+  0 0 1 1  NB. other
+  0 2 1 0  NB. letter
+)
+words=: (0;s;m) ;: tolower fread '/dev/stdin'
+exit '%d %s' echo@sprintf \:~ (#;{.) /.~ words

--- a/simple-j.ijs
+++ b/simple-j.ijs
@@ -1,0 +1,4 @@
+#! /usr/bin/env ijconsole
+load 'format/printf'
+words=: a: -.~ ' ' splitstring (LF,' ') rplc~ fread '/dev/stdin'
+exit '%d %s' printf"1 \:~ (#;{.) /.~ words

--- a/simple-j.ijs
+++ b/simple-j.ijs
@@ -1,4 +1,4 @@
 #! /usr/bin/env ijconsole
 load 'format/printf'
-words=: a: -.~ ' ' splitstring (LF,' ') rplc~ fread '/dev/stdin'
+words=: a: -.~ ' ' splitstring (LF,' ') rplc~ tolower fread '/dev/stdin'
 exit '%d %s' printf"1 \:~ (#;{.) /.~ words


### PR DESCRIPTION
abbreviated benchmark results:
```
Language      | Simple | Optimized | Notes
------------- | ------ | --------- | -----
`grep`        |   0.04 |      0.04 | `grep` baseline; optimized sets `LC_ALL=C`
`wc -w`       |   0.25 |      0.36 | `wc` baseline; optimized sets `LC_ALL=C`
J             |   4.94 |      1.81 | by jrfondren 
```

Simple:
- read entire file
- replace newlines with spaces
- split by spaces to get words
- remove empty boxes created by the split of consecutive spaces
- use Key (`/.` in J, ⌸ in DyalogAPL) and Grade down to get sorted word counts

Optimized:
- allow unlimited output and use echo@sprintf to reduce I/O syscalls
- split words with a custom Sequential Machine (`;:`), a little FSM that only cares about letters vs. non-letters