### PR TITLE
optimized.js 12% faster using {num:1} and readSync

### DIFF
--- a/optimized.js
+++ b/optimized.js
@@ -1,49 +1,58 @@
 "use strict";
-
+const fs = require("fs");
 const dict = {};
 
 // Calls itemHandler on each substring terminated by the token.
 // Returns any leftover characters in the string
 const forEachTerminated = (str, token, itemHandler) => {
-  let lastIndex = 0;
+    let lastIndex = 0;
 
-  while (true) {
-    const index = str.indexOf(token, lastIndex);
+    for (;;) {
+        const index = str.indexOf(token, lastIndex);
 
-    if (index === -1) break;
-    itemHandler(str.slice(lastIndex, index));
+        if (index === -1) break;
+        itemHandler(str.slice(lastIndex, index));
 
-    lastIndex = index + 1;
-  }
+        lastIndex = index + 1;
+    }
 
-  return str.slice(lastIndex);
+    return str.slice(lastIndex);
 };
 
-const wordHandler = word => {
-  if(word.length === 0) return;
-  dict[word] = (dict[word] || 0) + 1;
+const wordHandler = (word) => {
+    if (word.length === 0) return;
+    const item = dict[word];
+    if (item !== undefined) {
+        item.num++;
+    } else {
+        dict[word] = {num:1};
+    }
 };
 
-const lineHandler = line => {
-  if(line.length === 0) return;
-  wordHandler(forEachTerminated(line, " ", wordHandler));
+const lineHandler = (line) => {
+    if (line.length === 0) return;
+    wordHandler(forEachTerminated(line, " ", wordHandler));
 };
 
 const endHandler = () => {
-  const entries = Object.entries(dict);
-  entries.sort((a, b) =>  b[1] - a[1]);
-  process.stdout.write(entries.map((entry) => `${entry[0]} ${entry[1]}\n`).join(""));
+    const keys = Object.keys(dict);
+    keys.sort((a, b) => dict[b].num - dict[a].num);
+    process.stdout.write(keys.map((key) => `${key} ${dict[key].num}\n`).join(""));
 };
 
 let buffer = "";
-process.stdin.setEncoding("utf-8");
-process.stdin.resume();
-
-process.stdin.on("data", (data) => {
-  buffer = forEachTerminated(buffer + data.toLowerCase(), "\n", lineHandler);
-});
-
-process.stdin.on("end", () => {
-  if(buffer.length > 0) lineHandler(buffer);
-  endHandler();
-});
+const BUFSIZE = 64 * 1024;
+const encoding = "utf-8";
+const buf = Buffer.alloc(BUFSIZE, "", encoding);
+let bytesRead;
+const lineToken = "\n";
+for (;;) {
+    bytesRead = fs.readSync(process.stdin.fd, buf, 0, BUFSIZE);
+    if (bytesRead > 0) {
+        buffer = forEachTerminated(buffer + buf.toString(encoding, 0, bytesRead).toLowerCase(), lineToken, lineHandler);
+    } else {
+        if (buffer.length > 0) lineHandler(buffer);
+        endHandler();
+        break;
+    }
+}


### PR DESCRIPTION
Based on the discussion in https://github.com/benhoyt/countwords/pull/71:

Using `{num:1}` and `fs.readSync(process.stdin.fd)` I got ~12% faster:

Current optimized.js:
```
    Benchmark #1: node ./optimized.js < ./kjvbible_x10.txt > /dev/null
       Time (mean ± σ):      1.006 s ±  0.017 s    [User: 918.4 ms, System: 126.3 ms]
       Range (min … max):    0.982 s …  1.086 s    100 runs
```

With `new RefNum(1)`
```
    Benchmark #1: node ./optimizedRefNum.js < ./kjvbible_x10.txt > /dev/null
       Time (mean ± σ):     969.5 ms ±  36.9 ms    [User: 888.0 ms, System: 127.5 ms]
       Range (min … max):   934.3 ms … 1091.8 ms    100 runs
```

With `{num:1}`
```
    Benchmark #1: node ./optimizedObj.js < ./kjvbible_x10.txt > /dev/null
        Time (mean ± σ):     954.0 ms ±  10.7 ms    [User: 874.1 ms, System: 126.0 ms]
        Range (min … max):   938.7 ms … 989.9 ms    100 runs
```

With `fs.readSync`
```
    Benchmark #1: node ./optimizedReadSync.js < ./kjvbible_x10.txt > /dev/null
       Time (mean ± σ):     963.7 ms ±  24.4 ms    [User: 883.0 ms, System: 114.6 ms]
       Range (min … max):   941.1 ms … 1121.1 ms    100 runs
```

With `{num:1}` and `fs.readSync`
```
    Benchmark #1: node ./optimizedObjReadSync.js < ./kjvbible_x10.txt > /dev/null
        Time (mean ± σ):     886.2 ms ±  13.6 ms    [User: 807.8 ms, System: 114.2 ms]
        Range (min … max):   868.0 ms … 943.2 ms    100 runs
```