### PR TITLE
Rust

### DIFF
--- a/rust/bonus/main.rs
+++ b/rust/bonus/main.rs
@@ -17,10 +17,10 @@
 // The gauntlet has been laid down. How hard is to port this program to other
 // languages? And when you do, what does its performance look like?
 
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 
 use bstr::{io::BufReadExt, BStr, BString, ByteSlice};
-use fxhash::{FxHashMap as HashMap};
+use fxhash::FxHashMap as HashMap;
 
 fn main() {
     // Rust blocks the broken pipe signal by default, and instead returns it as
@@ -56,8 +56,10 @@ fn try_main() -> anyhow::Result<()> {
     let mut ordered: Vec<_> = counts.into_iter().collect();
     ordered.sort_unstable_by_key(|&(_, count)| count);
 
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::new(stdout.lock());
     for (word, count) in ordered.into_iter().rev() {
-        writeln!(io::stdout(), "{} {}", word, count)?;
+        writeln!(stdout, "{} {}", word, count)?;
     }
     Ok(())
 }

--- a/rust/optimized-customhashmap/main.rs
+++ b/rust/optimized-customhashmap/main.rs
@@ -12,7 +12,7 @@
 
 use std::{
     error::Error,
-    io::{self, Read, Write},
+    io::{self, BufWriter, Read, Write},
 };
 
 fn main() {
@@ -69,8 +69,10 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     let mut ordered = counts.into_counts();
     ordered.sort_unstable_by_key(|&(_, count)| count);
 
+	let stdout = io::stdout();
+	let mut stdout = BufWriter::new(stdout.lock());
     for (word, count) in ordered.into_iter().rev() {
-        writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
+        writeln!(stdout, "{} {}", std::str::from_utf8(&word)?, count)?;
     }
     Ok(())
 }

--- a/rust/optimized-unsafe/Cargo.toml
+++ b/rust/optimized-unsafe/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "optimized"
+version = "0.1.0"
+authors = ["Andrew Gallant <jamslam@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "countwords"
+path = "main.rs"
+
+[dependencies]
+fxhash = "0.2.1"
+
+[profile.release]
+debug = true

--- a/rust/optimized-unsafe/main.rs
+++ b/rust/optimized-unsafe/main.rs
@@ -86,7 +86,7 @@ fn increment<'a>(keys_outer: &'a Cell<Vec<u8>>, counts: &mut HashMap<&'a [u8], u
     assert!(keys.len() + word.len() <= keys.capacity());
     keys.extend_from_slice(word);
     // Safety: extend the lifetime of keys since are reusing the same buffer like an arena
-    let word = unsafe { std::mem::transmute(&keys[start..start + word.len()]) };
+    let word: &'a [u8] = unsafe { std::mem::transmute(&keys[start..start + word.len()]) };
     counts.insert(word, 1);
     keys_outer.set(keys); // store it back
 }

--- a/rust/optimized-unsafe/main.rs
+++ b/rust/optimized-unsafe/main.rs
@@ -1,0 +1,92 @@
+// This version is similar to optimized except it uses arena to store the
+// keys rather than having separate allocation for each new key.
+//
+// It would have similar results if one uses bumpalo or typed-arena, we
+// just didn't use any libraries here, or maybe this one could be slightly
+// faster because it uses Cell instead of RefCell.
+
+use std::cell::Cell;
+use std::error::Error;
+use std::io::{self, BufWriter, Read, Write};
+
+use fxhash::FxHashMap as HashMap;
+
+fn main() {
+    if let Err(err) = try_main() {
+        eprintln!("{}", err);
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> Result<(), Box<dyn Error>> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    let keys = Cell::new(Vec::with_capacity(256 * 1024)); // more than enough
+    let mut counts: HashMap<&[u8], u64> = HashMap::default();
+    let mut buf = vec![0; 64 * (1 << 10)];
+    let mut offset = 0;
+    let mut start = None;
+    loop {
+        let nread = stdin.read(&mut buf[offset..])?;
+        if nread == 0 {
+            if offset > 0 {
+                increment(&keys, &mut counts, &buf[..offset + 1]);
+            }
+            break;
+        }
+        let buf = &mut buf[..offset + nread];
+
+        for i in (0..buf.len()).skip(offset) {
+            let b = buf[i];
+            if b'A' <= b && b <= b'Z' {
+                buf[i] += b'a' - b'A';
+            }
+            if b == b' ' || b == b'\n' {
+                if let Some(start) = start.take() {
+                    increment(&keys, &mut counts, &buf[start..i]);
+                }
+            } else if start.is_none() {
+                start = Some(i);
+            }
+        }
+        if let Some(ref mut start) = start {
+            offset = buf.len() - *start;
+            buf.copy_within(*start.., 0);
+            *start = 0;
+        } else {
+            offset = 0;
+        }
+    }
+
+    let mut ordered: Vec<_> = counts.into_iter().collect();
+    ordered.sort_unstable_by_key(|&(_, count)| count);
+
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::new(stdout.lock());
+    for (word, count) in ordered.into_iter().rev() {
+        writeln!(stdout, "{} {}", std::str::from_utf8(&word)?, count)?;
+    }
+    Ok(())
+}
+
+fn increment<'a>(keys_outer: &'a Cell<Vec<u8>>, counts: &mut HashMap<&'a [u8], u64>, word: &[u8]) {
+    // using 'counts.entry' would be more idiomatic here, but doing so requires
+    // allocating a new Vec<u8> because of its API. Instead, we do two hash
+    // lookups, but in the exceptionally common case (we see a word we've
+    // already seen), we only do one and without any allocs.
+    if let Some(count) = counts.get_mut(word) {
+        *count += 1;
+        return;
+    }
+    // store keys in another buffer to avoid unnecessary allocation for each key
+    let mut keys = keys_outer.take();
+    let start = keys.len();
+    // make sure if never gets larger than the keys buffer, if it reallocate the memory,
+    // the key references may be pointing to the wrong address
+    assert!(keys.len() + word.len() <= keys.capacity());
+    keys.extend_from_slice(word);
+    // Safety: extend the lifetime of keys since are reusing the same buffer like an arena
+    let word = unsafe { std::mem::transmute(&keys[start..start + word.len()]) };
+    counts.insert(word, 1);
+    keys_outer.set(keys); // store it back
+}

--- a/rust/optimized/main.rs
+++ b/rust/optimized/main.rs
@@ -19,7 +19,7 @@ use std::{
 //
 // N.B. This crate brings in a new hashing function. We still use std's hashmap
 // implementation.
-use fxhash::{FxHashMap as HashMap};
+use fxhash::FxHashMap as HashMap;
 
 fn main() {
     if let Err(err) = try_main() {
@@ -32,18 +32,18 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     let stdin = io::stdin();
     let mut stdin = stdin.lock();
     let mut counts: HashMap<Vec<u8>, u64> = HashMap::default();
-    let mut buf = vec![0; 64 * (1<<10)];
+    let mut buf = vec![0; 64 * (1 << 10)];
     let mut offset = 0;
     let mut start = None;
     loop {
         let nread = stdin.read(&mut buf[offset..])?;
         if nread == 0 {
             if offset > 0 {
-                increment(&mut counts, &buf[..offset+1]);
+                increment(&mut counts, &buf[..offset + 1]);
             }
             break;
         }
-        let buf = &mut buf[..offset+nread];
+        let buf = &mut buf[..offset + nread];
 
         for i in (0..buf.len()).skip(offset) {
             let b = buf[i];

--- a/rust/simple/main.rs
+++ b/rust/simple/main.rs
@@ -18,7 +18,7 @@
 use std::{
     collections::HashMap,
     error::Error,
-    io::{self, BufRead, Write},
+    io::{self, BufRead, BufWriter, Write},
 };
 
 fn main() {
@@ -46,8 +46,10 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     let mut ordered: Vec<_> = counts.into_iter().collect();
     ordered.sort_by_key(|&(_, count)| count);
 
+    let stdout = io::stdout();
+    let mut stdout = BufWriter::new(stdout.lock());
     for (word, count) in ordered.into_iter().rev() {
-        writeln!(io::stdout(), "{} {}", word, count)?;
+        writeln!(stdout, "{} {}", word, count)?;
     }
     Ok(())
 }

--- a/test.sh
+++ b/test.sh
@@ -40,6 +40,11 @@ cargo build --release --manifest-path rust/optimized/Cargo.toml
 ./rust/optimized/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Rust optimized-unsafe
+cargo build --release --manifest-path rust/optimized-unsafe/Cargo.toml
+./rust/optimized-unsafe/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
 echo Rust optimized trie
 cargo build --release --manifest-path rust/optimized-trie/Cargo.toml
 ./rust/optimized-trie/target/release/countwords <kjvbible_x10.txt | python3 normalize.py >output.txt


### PR DESCRIPTION
cc @BurntSushi 
cc @vbarrielle I addressed your comments, added the assert

```
> hyperfine 'target/release/countwords < ../../kjvbible.txt'
Benchmark #1: target/release/countwords < ../../kjvbible.txt
  Time (mean ± σ):      43.1 ms ±  12.9 ms    [User: 40.2 ms, System: 2.8 ms]
  Range (min … max):    30.9 ms …  63.8 ms    76 runs
```

The other commit is to use buffered stdout as well as locking stdout which will make it faster.

Follow up of #87