### PR TITLE
Add optimized zig version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ optimized.cmx
 optimized.o
 simple-kotlin.jar
 simple-zig
+optimized-zig
 zig-cache
 /.idea
 java/*.class

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Thanks to these contributors for additional language versions:
 * Ruby: [Bill Mill](https://github.com/llimllib), with input from [Niklas](https://github.com/nhh)
 * Rust: [Andrew Gallant](https://github.com/BurntSushi)
 * Swift: [Daniel Müllenborn](https://github.com/damuellen)
-* Zig: [ifreund](https://github.com/ifreund) and [matu3ba](https://github.com/matu3ba)
+* Zig: [ifreund](https://github.com/ifreund) and [matu3ba](https://github.com/matu3ba) and [ansingh](https://github.com/ansingh)
 
 See other versions [on Rosetta Code](https://rosettacode.org/wiki/Word_frequency).

--- a/benchmark.py
+++ b/benchmark.py
@@ -44,7 +44,7 @@ programs = [
     ('Kotlin', 'java -jar simple-kotlin.jar', None, 'by Kazik Pogoda'),
     ('Lua', 'luajit simple.lua', 'luajit optimized.lua', 'by themadsens; runs under luajit'),
     ('Java', 'java -server -cp ./java simple', 'java -server -cp ./java optimized', 'by Iulian Plesoianu'),
-    ('Zig', './simple-zig', None, 'by ifreund and matu3ba'),
+    ('Zig', './simple-zig', './optimized-zig', 'by ifreund and matu3ba and ansingh'),
     ('Common Lisp', './simple-cl', None, 'by Brad Svercl'),
 ]
 

--- a/optimized.zig
+++ b/optimized.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const hash_map = std.hash_map;
+const murmur = std.hash.murmur;
+const WordMap = std.HashMap([]const u8, u32, hashString, hash_map.eqlString, 80);
+
+pub fn main() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const ally = &arena.allocator;
+
+    var words = WordMap.init(ally);
+    const stdin = std.io.getStdIn().reader();
+    comptime const buf_len: usize = 65536;
+    var buf: [buf_len + 8]u8 align(@alignOf(u64)) = undefined;
+    var numread: usize = try stdin.read(buf[0..buf_len]);
+
+    while (numread > 0) {
+        // margin word to stop the loop without bound checks
+        buf[numread] = ' ';
+        buf[numread + 1] = 'a';
+        buf[numread + 2] = ' ';
+
+        // find words and count them
+        var wstart: usize = 0;
+        while (true) {
+            while (buf[wstart] <= ' ') : (wstart += 1) {}
+            var wend = wstart;
+            while (buf[wend] > ' ') : (wend += 1) {
+                buf[wend] = std.ascii.toLower(buf[wend]);
+            }
+
+            if (wend >= numread) break;
+
+            const word = buf[wstart..wend];
+            const ret = try words.getOrPut(word);
+            if (ret.found_existing) {
+                ret.entry.value += 1;
+            } else {
+                ret.entry.key = try ally.dupe(u8, word);
+                ret.entry.value = 1;
+            }
+
+            wstart = wend + 1;
+        }
+
+        // copy the unprocessed chars to the front of buffer
+        var remain: usize = 0;
+        if (wstart < numread) {
+            std.mem.copy(u8, &buf, buf[wstart..numread]);
+            remain = numread - wstart;
+        }
+
+        // fill the buffer again
+        numread = try stdin.read(buf[remain..buf_len]);
+        if (numread > 0) numread += remain;
+    }
+
+    // extract unique words and sort them based on counts
+    const words_slice = try ally.alloc(WordMap.Entry, words.count());
+    var i: usize = 0;
+    var it = words.iterator();
+    while (it.next()) |entry| : (i += 1) {
+        words_slice[i] = entry.*;
+    }
+    std.sort.sort(WordMap.Entry, words_slice, {}, compare);
+
+    // print sorted values in words_slice
+    var stdout = std.io.bufferedWriter(std.io.getStdOut().writer());
+    for (words_slice) |entry| {
+        try stdout.writer().print("{s} {d}\n", .{ entry.key, entry.value });
+    }
+    try stdout.flush();
+}
+
+fn compare(_: void, a: WordMap.Entry, b: WordMap.Entry) bool {
+    return a.value > b.value;
+}
+
+pub fn hashString(s: []const u8) u64 {
+    return std.hash.Murmur2_32.hash(s);
+}

--- a/test.sh
+++ b/test.sh
@@ -216,6 +216,11 @@ zig build-exe -OReleaseFast --name simple-zig simple.zig
 ./simple-zig <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Zig optimized
+zig build-exe -OReleaseFast --name optimized-zig optimized.zig
+./optimized-zig <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+
 echo Common Lisp simple
 sbcl --load simple.lisp --eval "(sb-ext:save-lisp-and-die #p\"simple-cl\" :toplevel #'main :executable t :purify t)"
 ./simple-cl <kjvbible_x10.txt | python3 normalize.py >output.txt


### PR DESCRIPTION
I've attempted to optimize the simple.zig by reading directly into a buffer and parsing the words manually. Also selected a different hash function for the map.

No unsafe usage, no custom hash implementation and it seems to run pretty fast (faster than optimized c, at least on my machine).