### PR TITLE
Add simple tcl version

### DIFF
--- a/simple.tcl
+++ b/simple.tcl
@@ -1,0 +1,10 @@
+#!/usr/bin/env tclsh
+fconfigure stdin -buffering line
+while {[gets stdin data] >= 0} {
+  foreach word [string tolower [split $data]] {
+    incr table($word)
+  }
+}
+foreach {word count} [lsort -decreasing -integer -index 1 -stride 2 [array get table]] {
+  puts "$word $count"
+}


### PR DESCRIPTION
Add solution in tcl. Version 8.6 or newer required due to use of -stride in lsort.

On my system:

| Language | Simple  |
|-----|-----|
| C | 0.323s |
 | tcl | 1.703s |
