### PR TITLE
Add simple Tcl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Thanks to these contributors for additional language versions:
 * Ruby: [Bill Mill](https://github.com/llimllib), with input from [Niklas](https://github.com/nhh)
 * Rust: [Andrew Gallant](https://github.com/BurntSushi)
 * Swift: [Daniel Müllenborn](https://github.com/damuellen)
+* Tcl: [William Ross](https://github.com/arideden)
 * Zig: [ifreund](https://github.com/ifreund) and [matu3ba](https://github.com/matu3ba) and [ansingh](https://github.com/ansingh)
 
 See other versions [on Rosetta Code](https://rosettacode.org/wiki/Word_frequency).

--- a/benchmark.py
+++ b/benchmark.py
@@ -46,6 +46,7 @@ programs = [
     ('Java', 'java -server -cp ./java simple', 'java -server -cp ./java optimized', 'by Iulian Plesoianu'),
     ('Zig', './simple-zig', './optimized-zig', 'by ifreund and matu3ba and ansingh'),
     ('Common Lisp', './simple-cl', None, 'by Brad Svercl'),
+    ('Tcl', 'tclsh simple.tcl', None, 'by William Ross'),
 ]
 
 times = []

--- a/simple.tcl
+++ b/simple.tcl
@@ -7,7 +7,7 @@ while {[gets stdin data] >= 0} {
 }
 # Remove the count of null elements resulting from the split function
 # being applied to consecutive whitespace in the input
-unset table()
+catch {unset table()} err
 foreach {word count} [lsort -decreasing -integer -index 1 -stride 2 [array get table]] {
   puts "$word $count"
 }

--- a/simple.tcl
+++ b/simple.tcl
@@ -1,10 +1,13 @@
 #!/usr/bin/env tclsh
 fconfigure stdin -buffering line
 while {[gets stdin data] >= 0} {
-  foreach word [string tolower [split $data]] {
+  foreach word [split [string tolower $data]] {
     incr table($word)
   }
 }
+# Remove the count of null elements resulting from the split function
+# being applied to consecutive whitespace in the input
+unset table()
 foreach {word count} [lsort -decreasing -integer -index 1 -stride 2 [array get table]] {
   puts "$word $count"
 }

--- a/simple.tcl
+++ b/simple.tcl
@@ -1,0 +1,10 @@
+#!/usr/bin/env tclsh
+fconfigure stdin -buffering line
+while {[gets stdin data] >= 0} {
+  foreach word [string tolower [split $data]] {
+    incr table($word)
+  }
+}
+foreach {word count} [lsort -decreasing -integer -index 1 -stride 2 [array get table]] {
+  puts "$word $count"
+}

--- a/test.sh
+++ b/test.sh
@@ -226,3 +226,7 @@ sbcl --load simple.lisp --eval "(sb-ext:save-lisp-and-die #p\"simple-cl\" :tople
 ./simple-cl <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
+echo Tcl simple
+tclsh simple.tcl <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt
+

--- a/versions.sh
+++ b/versions.sh
@@ -30,6 +30,7 @@ kotlinc -version 2>&1 | grep 'info:' >>versions.txt
 javac -version >>versions.txt
 echo -n 'Zig: ' >>versions.txt && zig version >>versions.txt
 sbcl --version >>versions.txt
+echo 'puts "Tcl: [info patchlevel]"' | tclsh >> versions.txt
 
 echo "For some reason gforth --version doesn't redirect! Append this to versions.txt manually:"
 ../gforth/gforth-fast --version 2>&1 >>versions.txt


### PR DESCRIPTION
Add solution in Tcl. Version 8.6 or newer required due to use of -stride in lsort.

On my system:

Language      | Simple | Optimized | Notes
------------- | ------ | --------- | -----
C             |   1.57 |      0.32 | 
Python        |   4.49 |      2.49 | 
Perl          |   4.65 |           | by Charles Randall
Ruby          |   5.65 |           | by Bill Mill
Swift         |   8.79 |           | by Daniel Muellenborn
Tcl           |  10.87 |           | by William Ross