### PR TITLE
Add simple Haxe version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Thanks to these contributors for additional language versions:
 * D: [Ross Lonstein](https://github.com/rlonstein)
 * F#: [Yuriy Ostapenko](https://github.com/uncleyo)
 * Go: [Miguel Angel](https://github.com/ntrrg) - simplifying the Go optimized version; [Joshua Corbin](https://github.com/jcorbin) - adding a [parallel Go version](https://github.com/benhoyt/countwords/blob/9db2ab6808921e649fc5212c00712e61edf6fa1c/parallel.go) for demonstration
+* Haxe: [Osman Turan](https://github.com/osman-turan)
 * Java: [Iulian Pleșoianu](https://github.com/bit-twit)
 * JavaScript: [Dani Biró](https://github.com/Daninet) and [Flo Hinze](https://github.com/laubsauger)
 * Julia: [Alessandro Melis](https://github.com/alemelis)

--- a/Simple.hx
+++ b/Simple.hx
@@ -1,0 +1,46 @@
+class Entry {
+	public var word:String;
+	public var count:Int;
+
+	public function new(word, count) {
+		this.word = word;
+		this.count = count;
+	}
+}
+
+class Simple {
+	static function main() {
+		var dict = new Map<String, Int>();
+
+		try {
+			while (true) {
+				var line = Sys.stdin().readLine();
+				if (line.length == 0) {
+					continue;
+				}
+
+				var words = line.split(' ');
+				for (word in words) {
+					if (word.length == 0) {
+						continue;
+					}
+
+					var key = word.toLowerCase();
+					var count = dict[key];
+					dict[key] = count != null ? count + 1 : 1;
+				}
+			}
+		} catch (e:haxe.io.Eof) {
+			var entries = new Array<Entry>();
+			for (word in dict.keys()) {
+				entries.push(new Entry(word, dict[word]));
+			}
+
+			entries.sort(function(a, b) return b.count - a.count);
+
+			for (entry in entries) {
+				Sys.println('${entry.word} ${entry.count}');
+			}
+		}
+	}
+}

--- a/benchmark.py
+++ b/benchmark.py
@@ -48,6 +48,7 @@ programs = [
     ('Common Lisp', './simple-cl', None, 'by Brad Svercl'),
     ('Pascal', './simple-pas', None, 'by Osman Turan'),
     ('Tcl', 'tclsh simple.tcl', None, 'by William Ross'),
+    ('Haxe', 'haxe -main Simple --interp', None, 'by Osman Turan'),
 ]
 
 times = []

--- a/test.sh
+++ b/test.sh
@@ -234,3 +234,7 @@ git diff --exit-code output.txt
 echo Tcl simple
 tclsh simple.tcl <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
+
+echo Haxe simple
+haxe -main Simple --interp <kjvbible_x10.txt | python3 normalize.py >output.txt
+git diff --exit-code output.txt

--- a/versions.sh
+++ b/versions.sh
@@ -32,6 +32,7 @@ echo -n 'Zig: ' >>versions.txt && zig version >>versions.txt
 sbcl --version >>versions.txt
 echo -n 'Pascal: ' >>versions.txt && fpc -iW >>versions.txt
 echo 'puts "Tcl: [info patchlevel]"' | tclsh >> versions.txt
+echo -n 'Haxe: ' >>versions.txt && haxe --version >>versions.txt
 
 echo "For some reason gforth --version doesn't redirect! Append this to versions.txt manually:"
 ../gforth/gforth-fast --version 2>&1 >>versions.txt


### PR DESCRIPTION
I have implemented the simple Haxe version which runs with `-interp` flag. So it's not compiled to C++ or any other target. This is not ideal performance-wise. But I think it fits in the "simple" usage.

| Language   | Simple | Optimized |
| ---------- | ------ | --------- |
| JavaScript | 2.01   | 1.15      |
| Haxe       | 19.00  |           |