### PR TITLE
fix: use latest OCaml compiler

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -184,7 +184,7 @@ php simple.php <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 
 echo OCaml simple
-ocamlopt.opt -O3 simple.ml -o simple-ml
+docker run --rm --security-opt label=disable --cap-add SYS_ADMIN --user $(id -u):$(id -g) --volume $(pwd):/countwords --workdir /countwords ocaml/opam:debian-ocaml-4.12-flambda ocamlopt.opt -O3 simple.ml -o simple-ml
 ./simple-ml <kjvbible_x10.txt | python3 normalize.py >output.txt
 git diff --exit-code output.txt
 

--- a/versions.txt
+++ b/versions.txt
@@ -20,7 +20,7 @@ LDC - the LLVM D compiler (1.25.1):
   based on DMD v2.095.1 and LLVM 11.0.1
   built with LDC - the LLVM D compiler (1.25.1)
 PHP 7.4.3 (cli) (built: Oct  6 2020 15:47:56) ( NTS )
-OCaml: 4.08.1
+OCaml: 4.12-flambda
 LuaJIT 2.1.0-beta3 -- Copyright (C) 2005-2017 Mike Pall. http://luajit.org/
 info: kotlinc-jvm 1.4.31 (JRE 14.0.2+12-Ubuntu-120.04)
 javac 14.0.2


### PR DESCRIPTION
Not sure how open you are to using docker but this will use a compiler [version that's almost 3 years newer](https://ocaml.org/releases/index.html) and produces a ~20% improvement on my machine.