### PR TITLE
Rewriting for loops as closures provides another speed up

### DIFF
--- a/rust/optimized/main.rs
+++ b/rust/optimized/main.rs
@@ -8,7 +8,7 @@
 
 use std::{
     error::Error,
-    io::{self, Read, Write},
+    io::{self, Read, Write, BufWriter},
 };
 
 // std uses a cryptographically secure hashing algorithm by default, which is
@@ -35,6 +35,8 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     let mut buf = vec![0; 64 * (1 << 10)];
     let mut offset = 0;
     let mut start = None;
+    let mut buffer = BufWriter::new(io::stdout());
+
     loop {
         let nread = stdin.read(&mut buf[offset..])?;
         if nread == 0 {
@@ -71,7 +73,7 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     ordered.sort_unstable_by_key(|&(_, count)| count);
 
     for (word, count) in ordered.into_iter().rev() {
-        writeln!(io::stdout(), "{} {}", std::str::from_utf8(&word)?, count)?;
+        writeln!(buffer, "{} {}", std::str::from_utf8(&word)?, count)?;
     }
     Ok(())
 }

--- a/rust/optimized/main.rs
+++ b/rust/optimized/main.rs
@@ -76,14 +76,17 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     ordered.sort_unstable_by_key(|&(_, count)| count);
     
     let res = ordered.into_iter().rev().try_for_each( |(word, count)|
-        writeln!(out_buffer, "{} {}", std::str::from_utf8(&word).unwrap(), count)
-    );
+        match std::str::from_utf8(&word) {
+            Ok(word_str) => {
+                match writeln!(out_buffer, "{} {}", word_str, count) {
+                    Ok(_) => Ok(()),
+                    Err(e) => Err(Box::new(e).into()),
+                }
+            },
+            Err(e) => Err(Box::new(e).into()),
+        });
 
-    if let Err(e) = res {
-        Err(Box::new(e))
-    } else {
-        Ok(())
-    }
+    res
 }
 
 fn increment(counts: &mut HashMap<Vec<u8>, u64>, word: &[u8]) {


### PR DESCRIPTION
Don't hate me!  I appreciate your attention to this and the last PR.  I'm sure I'm just as wrong (once again), but, rewriting in the functional form *seems to* provide a hefty speed up as well.  See:

```
hyperfine -w 3 "cat ../../kjvbible_x10.txt | ./target/release/countwords" "cat ../../kjvbible_x10.txt | ../optimized/target/release/countwords"
Benchmark 1: cat ../../kjvbible_x10.txt | ./target/release/countwords
  Time (mean ± σ):     175.2 ms ±   0.5 ms    [User: 172.8 ms, System: 10.5 ms]
  Range (min … max):   174.5 ms … 176.2 ms    16 runs

Benchmark 2: cat ../../kjvbible_x10.txt | ../optimized/target/release/countwords
  Time (mean ± σ):     223.6 ms ±   0.8 ms    [User: 216.1 ms, System: 14.2 ms]
  Range (min … max):   222.3 ms … 225.6 ms    13 runs

Summary
  'cat ../../kjvbible_x10.txt | ./target/release/countwords' ran
    1.28 ± 0.01 times faster than 'cat ../../kjvbible_x10.txt | ../optimized/target/release/countwords'
```